### PR TITLE
Add flag for SELinux configuration

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -19,11 +19,7 @@ jobs:
           ansible
           ansible-lint
           yamllint
-          molecule
-          molecule-docker
-          molecule-podman
 
-      - name: test playbook
-        run: molecule test --driver-name docker
-        env:
-          PY_COLORS: '1'
+      - run: ansible-lint .
+
+      - run: yamllint -c .yamllint .

--- a/README.md
+++ b/README.md
@@ -30,9 +30,13 @@ Also, if you copy a custom `root.conf` in place, it will not be overwritten by t
 
 ### Security and Firewall Related
 
-This role can enable nginx for firewalld or ufw.
-However, you have to tell it so explicitely by either setting `configure_for_firewalld` or `configure_for_ufw` to `true`.
-If SELinux is on the system and active, this role automatically enables nginx to act as a reverse proxy.
+This role can open ports for Nginx in firewalld or ufw.
+It can also set the SELinux boolean to allow Nginx to act as a reverse proxy.
+These settings are disabled by default and you have to explicitely enable them:
+
+- `configure_for_firewalld: true`
+- `configure_for_ufw: true`
+- `configure_for_selinux: true`
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ nginx_http_config: conf.d/http.conf
 
 configure_for_firewalld: false
 configure_for_ufw: false
+configure_for_selinux: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: reload nginx
-  service:
+- name: Reload nginx
+  ansible.builtin.service:
     name: nginx
     state: reloaded

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,12 +6,13 @@ galaxy_info:
   namespace: elan
   description: Installs and prepares Nginx as reverse proxy
   license: BSD-3-Clause
-  min_ansible_version: 2.9
+  min_ansible_version: 2.9.0
   platforms:
     - name: EL
       versions:
-        - 7
-        - 8
+        - '7'
+        - '8'
+        - '9'
     - name: Debian
       versions:
         - all

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -22,7 +22,7 @@
         content: 'location /test { return 204; }'
         dest: /etc/nginx/conf.d/locations/test.conf
 
-    - name: reload nginx
+    - name: Reload nginx
       service:
         name: nginx
         state: reloaded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: install nginx
-  package:
+- name: Install nginx
+  ansible.builtin.package:
     name: nginx
     state: present
 
-- name: create configuration directories
-  file:
+- name: Create configuration directories
+  ansible.builtin.file:
     path: /etc/nginx/{{ item }}
     state: directory
     mode: '0755'
@@ -17,14 +17,14 @@
     - conf.d
     - conf.d/locations
 
-- name: configure nginx
-  template:
+- name: Configure nginx
+  ansible.builtin.template:
     src: '{{ item.src }}'
     dest: /etc/nginx/{{ item.dest }}
     mode: '0644'
     owner: root
     group: root
-  notify: reload nginx
+  notify: Reload nginx
   when: item.src is truthy
   loop:
     - src: '{{ nginx_base_config }}'
@@ -34,54 +34,55 @@
     - src: '{{ nginx_http_config }}'
       dest: conf.d/http.conf
 
-- name: create root locations file
-  copy:
+- name: Create root locations file
+  ansible.builtin.copy:
     src: root.conf
     dest: /etc/nginx/conf.d/locations/root.conf
     owner: root
     group: root
     mode: '0644'
     force: false
-  notify: reload nginx
+  notify: Reload nginx
 
 - name: Copy Diffie-Hellmann parameter
-  copy:
+  ansible.builtin.copy:
     src: dhparam.pem
     dest: /etc//nginx/ssl/dhparam.pem
     owner: root
     group: root
     mode: '0640'
-  notify: reload nginx
+  notify: Reload nginx
 
-- name: install dummy tls certificate
-  copy:
+- name: Install dummy tls certificate
+  ansible.builtin.copy:
     src: dummy-tls-{{ item }}.pem
     dest: /etc/nginx/ssl/{{ inventory_hostname }}.{{ item }}
     owner: root
     group: root
     mode: '0400'
     force: false
-  notify: reload nginx
+  notify: Reload nginx
   loop:
     - key
     - crt
 
 - name: SELinux settings
+  when: configure_for_selinux
   block:
-    - name: install dependencies
-      package:
+    - name: Install dependencies
+      ansible.builtin.package:
         name:
           - python3-libselinux
           - python3-libsemanage
-    - name: allow nginx to act as reverse proxy
-      seboolean:
+
+    - name: Allow nginx to act as reverse proxy
+      ansible.posix.seboolean:
         name: httpd_can_network_connect
         state: true
         persistent: true
-  when: ansible_selinux is defined and ansible_selinux != false and ansible_selinux.status == 'enabled'  # yamllint disable-line rule:line-length
 
-- name: configure for firewalld
-  firewalld:
+- name: Configure firewalld
+  ansible.posix.firewalld:
     service: '{{ item }}'
     state: enabled
     permanent: true
@@ -91,14 +92,14 @@
     - https
   when: configure_for_firewalld
 
-- name: configure for ufw
-  ufw:
+- name: Configure ufw
+  community.general.ufw:
     rule: allow
     name: Nginx Full
   when: configure_for_ufw
 
-- name: enable nginx
-  service:
+- name: Enable nginx
+  ansible.builtin.service:
     name: nginx
     enabled: true
     state: started


### PR DESCRIPTION
This patch adds a new flag `configure_for_selinux` to the role, replacing the magic trying to figure out if we should run the SELinux related tasks or not.

This also updates the scripts so that `ansible-lint` does no longer complain.