### PR TITLE
Remove mitigation for broken Molecule

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -31,16 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # ansible-compat < 4 to mitigate
-      # https://github.com/ansible-community/molecule/issues/3903
       - name: install dependencies
-        run: >
-          pip3 install
-          ansible
-          'ansible-compat < 4'
-          ansible-lint
-          molecule
-          yamllint
+        run: pip3 install -r .dev_requirements.txt
 
       - name: create lxc container
         uses: lkiesow/setup-lxc-container@v1


### PR DESCRIPTION
This patch removes the mitigation for the broken molecule dependency. It should no longer be necessary.

This fixes #6