### PR TITLE
Don't include subdomains in HSTS

### DIFF
--- a/files/tls.conf
+++ b/files/tls.conf
@@ -22,7 +22,7 @@ ssl_ciphers HIGH:!aNULL:!MD5:!3DES;
 # stripping [2].
 # [1] https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
 # [2] https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
-add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+add_header Strict-Transport-Security "max-age=31536000;";
 
 # When serving user-supplied content, include a X-Content-Type-Options:
 # nosniff header along with the Content-Type: header, to disable


### PR DESCRIPTION
While we want Strict-Transport-Security, automatically enforcing it for subdomains could cause trouble if someone unknowingly deploys this to their main domain.