### PR TITLE
Allow TLS 1.2

### DIFF
--- a/files/tls.conf
+++ b/files/tls.conf
@@ -1,6 +1,5 @@
-# Turn off old and possibly unsafe SSL protocols. TLSv1 is still necessary
-# for some older devices but I do not care.
-ssl_protocols TLSv1.3;
+# Turn off old and possibly unsafe SSL/TLS protocols.
+ssl_protocols TLSv1.2 TLSv1.3;
 
 # Enable session resumption to improve https performance
 # http://vincent.bernat.im/en/blog/2011-ssl-session-reuse-rfc5077.html


### PR DESCRIPTION
This patch updates the default TLS configuration to be a bit more lenient and still allow TLS 1.2 since it seems like some fairly modern systems still do not support 1.3.