### PR TITLE
Fix conflict between molecule  and ansible-lint

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,7 +32,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: install dependencies
-        run: pip3 install -r .dev_requirements.txt
+        run: >
+          pip3 install
+          ansible
+          molecule
 
       - name: create lxc container
         uses: lkiesow/setup-lxc-container@v1


### PR DESCRIPTION
Molecule and ansible-lint require ansible-compat in different versions and installing both currently breaks molecule (again).

This patchremoves ansible-lint from the Molecule workflow since we don't need it in there anyway. We have a separate workflow for that.

More details:
https://github.com/ansible-community/molecule/issues/3903#issuecomment-1578330662